### PR TITLE
Fix GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,16 +15,8 @@ jobs:
         run: |
           curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
-      - name: Build WASM
-        run: |
-          wasm-pack build --target web --out-dir pkg
-
-      - name: Prepare static site
-        run: |
-          mkdir -p dist/js
-          cp -r static/* dist/
-          cp -r js/* dist/js/
-          cp -r pkg dist/
+      - name: Build static site
+        run: bash ./build.sh
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/static/index.html
+++ b/static/index.html
@@ -44,6 +44,6 @@
       }
     </script>
 
-    <script type="module" src="../js/index.js"></script>
+    <script type="module" src="./js/index.js"></script>
   </body>
 </html>


### PR DESCRIPTION

- rely on local `build.sh` for GitHub Actions build
- fix `index.html` script path so JS loads correctly on GitHub Pages
